### PR TITLE
Possible solution for #27

### DIFF
--- a/src/sly.js
+++ b/src/sly.js
@@ -1087,6 +1087,9 @@
 				if (pos.cur === pos.dest) {
 					trigger('moveEnd');
 				}
+				if (dragging.init == 0 && event.type==='touchend') {
+					trigger('touchclick', event.target);
+				}
 			}
 		}
 
@@ -1211,6 +1214,11 @@
 		function trigger(name, arg1, arg2, arg3, arg4) {
 			// Common arguments for events
 			switch (name) {
+				case 'touchclick':
+					arg2 = arg1;
+					arg1 = pos;
+					break;
+					
 				case 'active':
 					arg2 = arg1;
 					arg1 = $items;


### PR DESCRIPTION
New SLY "touch click" event when DOM event.type value is 'touchend' and dragging.init value is '0' (no move).
Necesary return the target where the DOM event happens.
