### PR TITLE
prevent default touch scroll action if page scroll is not intended

### DIFF
--- a/src/sly.js
+++ b/src/sly.js
@@ -1399,6 +1399,25 @@
 			dragging.path = Math.sqrt(Math.pow(dragging.pathX, 2) + Math.pow(dragging.pathY, 2));
 			dragging.delta = within(o.horizontal ? dragging.pathX : dragging.pathY, dragging.deltaMin, dragging.deltaMax);
 
+      /**
+        Some mobile browsers (Chrome mainly) fire touchcancel event right after initial touch move,
+        so we need to prevent default behaviour if the items are meant to be dragged/scrolled.
+        We'll do this by checking if the px distance is within buffer for either x or y.
+      */
+      if (o.horizontal){
+        if (isToBeDragged(dragging.pointer.pageX, dragging.initX, 5)) {
+          stopDefault(event);
+        } else {
+          dragEnd();
+        }
+      } else {
+        if (isToBeDragged(dragging.pointer.pageY, dragging.initY, 5)) {
+          stopDefault(event);
+        } else {
+          dragEnd();
+        }
+      }
+
 			if (!dragging.locked && dragging.path > dragging.pathToLock) {
 				dragging.locked = 1;
 				if (o.horizontal ? Math.abs(dragging.pathX) < Math.abs(dragging.pathY) : Math.abs(dragging.pathX) > Math.abs(dragging.pathY)) {
@@ -1457,6 +1476,22 @@
 
 			dragging.init = 0;
 		}
+		
+    /**
+     * Check whether scroll position is outside of buffer.
+     *
+     * @return {Boolean}
+     */
+    function isToBeDragged(newVal, oldVal, buffer) {
+      console.log("new val: " + newVal + buffer);
+      console.log("oldVal: " + oldVal);
+      if (newVal + buffer < oldVal || newVal - buffer > oldVal) {
+        stopDefault(event);
+        return true;
+      } else {
+        return false;
+      }
+    }
 
 		/**
 		 * Check whether element is interactive.


### PR DESCRIPTION
This fixes #94

Chrome mobile browser fires touchcancel 200ms after touchmove so sometimes dragging becomes jittery as the browser thinks the page is to be touch scrolled.

http://stackoverflow.com/questions/20412982/javascript-any-workarounds-for-getting-chrome-for-android-to-fire-off-touchmove

The fix checks to see if the px movement is outside a buffer and then calls preventDefault() on the event to enable touchmove to fire correctly.
