### PR TITLE
Fix to activation of requested position when the "startAt" tile is non e...

### DIFF
--- a/src/sly.js
+++ b/src/sly.js
@@ -314,7 +314,8 @@
 					activate(rel.activeItem >= items.length ? items.length - 1 : 0, !lastItemsCount);
 				}
 				// Fix possible overflowing
-				slideTo(centeredNav && items.length ? items[rel.activeItem].center : within(pos.dest, pos.start, pos.end));
+				var activeItem = items[rel.activeItem];
+				slideTo(centeredNav && activeItem ? activeItem.center : within(pos.dest, pos.start, pos.end));
 			} else {
 				if (!self.initialized) {
 					slideTo(o.startAt, 1);


### PR DESCRIPTION
When initialising sly on a container with a "startAt" position that is greater than the number of existing tiles and the "itemNav" parameter is also set to "forceCentered", an error occurs: 

Uncaught TypeError: Cannot read property 'center' of undefined 

This commit fixes this error.
