### PR TITLE
Remove reference to jQuery variable

### DIFF
--- a/src/sly.js
+++ b/src/sly.js
@@ -459,7 +459,7 @@
 			// Use tweening for basic animations with known end point
 			else {
 				animation.time = min(+new Date() - animation.start, o.speed);
-				pos.cur = animation.from + animation.delta * jQuery.easing[o.easing](animation.time/o.speed, animation.time, 0, 1, o.speed);
+				pos.cur = animation.from + animation.delta * $.easing[o.easing](animation.time/o.speed, animation.time, 0, 1, o.speed);
 			}
 
 			// If there is nothing more to render break the rendering loop, otherwise request new animation frame.


### PR DESCRIPTION
I ran across this when testing this using another component that requires a different version of jQuery. It was causing an error.