### PR TITLE
Request for a customizable slidee

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -24,6 +24,8 @@ Sly call with all default options as defined in the source.
 
 ```js
 var frame = new Sly('#frame', {
+	slidee: null, // Selector for a customized slidee, in case there exists one more children inheriting FRAME. Default is SLIDEE, the first child of FRAME
+	
 	horizontal: false, // Switch to horizontal mode.
 
 	// Item based navigation

--- a/src/sly.js
+++ b/src/sly.js
@@ -61,7 +61,8 @@
 
 		// Frame
 		var $frame = $(frame);
-		var $slidee = $frame.children().eq(0);
+		// var $slidee = $frame.children().eq(0);
+		var $slidee = o.slidee || $frame.children().eq(0);
 		var frameSize = 0;
 		var slideeSize = 0;
 		var pos = {
@@ -2097,6 +2098,8 @@
 
 	// Default options
 	Sly.defaults = {
+		slidee: null, // Selector for a customized slidee, in case there exists one more children inheriting FRAME. Default is SLIDEE, the first child of FRAME
+		
 		horizontal: false, // Switch to horizontal mode.
 
 		// Item based navigation


### PR DESCRIPTION
Hope to see an `options.slidee` for a customized SLIDEE, in case there exists one more children inheriting FRAME, for if not doing so, the default SLIDEE must only be the first/only child of FRAME, which may feel bit stumbling.