### PR TITLE
Basic responsive support

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -90,6 +90,11 @@ var frame = new Sly('#frame', {
 	draggedClass:  'dragged', // Class for dragged elements (like SLIDEE or scrollbar handle).
 	activeClass:   'active',  // Class for active items and pages.
 	disabledClass: 'disabled' // Class for disabled navigation elements.
+
+	// Responsive variables
+	visibleItems: null, // Array with numbers of visible items at once for different resolutions, like [3,2,1].
+	screen_sm: 768,     // Breakpoint for mobile screens - more than 768 - tablets; less than 768 - mobile screens.
+	screen_md: 992    // Breakpoint for desctop screens - more than 992.
 });
 ```
 
@@ -523,3 +528,30 @@ Class added to buttons when they are disabled.
 Buttons are being disabled when there would be no action after pressing them. For example: the previous item button when the very first item is activated.
 
 If a button is a `<button>` or `<input>` element, it will also be marked with `disabled="disabled"` attribute.
+
+---
+
+###### Responsive
+
+---
+
+### visibleItems
+
+Type: `Array`
+Default: `null`
+
+Array with numbers of visible items at once for different resolutions, like [3,2,1] - [desctop, tablet, mobile]
+
+### screen_sm
+
+Type: `Integer`
+Default: `768`
+
+Breakpoint for mobile screens - more than 768 - tablets; less than 768 - mobile screens.
+
+### screen_md
+
+Type: `Integer`
+Default: `992`
+
+Breakpoint for desctop screens - more than 992.


### PR DESCRIPTION
Hi! 
I added basic responsve support for Sly - for desctop, tablet and mobile to src/sly.js

Added option visibleItems (array - null by default) - you can add [3,2,1] - that will shows 3 slides for desctop, 2 slides for tablet and 1 - for mobile. Also you don't need to add width for slide with css. 
Also it supports resizing (but it still buggy lil bit), so it useful for sites with % width.

Also added options screen_sm and screen_md with default values ( 768 and 992 px - based on bootstrap). So you can change your responsive breakpoints.

Hope it will be useful for you 
UPD: you can check how it works here: https://jsfiddle.net/vaedzqnz/
