### PR TITLE
Node/npm package support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/dist/sly.node.source.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+/dist/sly.node.source.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,24 @@
 module.exports = function (grunt) {
 	'use strict';
 
+	grunt.registerTask('node', 'Prepare node source', function() {
+		var fs = require('fs');
+		var done = this.async();
+		fs.readFile('src/sly.js', function(err, source) {
+			if (err) {
+				done(false);
+			} else {
+				var lines = source.toString().trim().split("\n");
+				lines[0] = lines[0].replace(/^;/, ';module.exports = ');
+				lines[lines.length-1] = lines[lines.length-1].replace('}(jQuery, window)', 'return Sly;}');
+				source = lines.join("\n");
+				fs.writeFile('dist/sly.node.source.js', source, function(err) {
+					done(!err);
+				});
+			}
+		});
+	});
+
 	// Override environment based line endings enforced by Grunt
 	grunt.util.linefeed = '\n';
 
@@ -41,6 +59,13 @@ module.exports = function (grunt) {
 				},
 				src: 'src/<%= pkg.name %>.js',
 				dest: 'dist/<%= pkg.name %>.js'
+			},
+			node: {
+				options: {
+					banner: '<%= meta.banner %>'
+				},
+				src: 'dist/<%= pkg.name %>.node.source.js',
+				dest: 'dist/<%= pkg.name %>.node.js'
 			}
 		},
 
@@ -80,6 +105,7 @@ module.exports = function (grunt) {
 	// Build task.
 	grunt.registerTask('build', function () {
 		grunt.task.run('clean');
+		grunt.task.run('node');
 		grunt.task.run('concat');
 		grunt.task.run('uglify');
 	});

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,7 +87,7 @@ module.exports = function (grunt) {
 					pkg: 'meta.json',
 				},
 			},
-			files: ['meta.json', '<%= pkg.name %>.jquery.json'],
+			files: ['meta.json', '<%= pkg.name %>.jquery.json', 'package.json'],
 		},
 
 		// Commit changes and tag the latest commit with a version from JSON file.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ $('#frame').sly(options);
 
 jQuery proxy is good when you want to create an instance and forget about it. For anything more complex, like using methods, events, accessing instance properties, ... use the constructor and work with the instance directly.
 
+In Node:
+
+```js
+var jQuery = require('jquery');
+var Sly = require('sly-scrolling')(jQuery, window);
+
+// now use Sly as above
+var options = {
+	horizontal: 1,
+	itemNav: 'basic',
+	speed: 300,
+	mouseDragging: 1,
+	touchDragging: 1
+};
+var frame = new Sly('#frame', options).init();
+```
+
 ## Download
 
 Latest stable release:

--- a/docs/Calling.md
+++ b/docs/Calling.md
@@ -1,5 +1,14 @@
 # Calling
 
+If using Sly in the Node.js environment, require and instantiate it first:
+
+```js
+var jQuery = require('jquery');
+var Sly = require('sly-scrolling')(jQuery, window);
+```
+
+Browser environments do not need this step.
+
 When you want to have a direct access to all methods and complete control over Sly:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "sly",
-	"version": "0.0.0",
+	"name": "sly-scrolling",
+	"version": "1.6.1",
 	"devDependencies": {
 		"grunt-contrib-jshint": "~0.7.2",
 		"grunt-contrib-uglify": "~0.6.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"homepage": "http://darsa.in/sly/",
 	"bugs": "https://github.com/darsain/sly/issues",
 	"license": "MIT",
+	"main": "dist/sly.node.js",
 	"repository": {"type": "git", "url": "https://github.com/darsain/sly"},
 	"peerDependencies": {
 		"jquery": ">=1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "sly-scrolling",
 	"version": "1.6.1",
+	"peerDependencies": {
+		"jquery": ">=1.7"
+	},
 	"devDependencies": {
 		"grunt-contrib-jshint": "~0.7.2",
 		"grunt-contrib-uglify": "~0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,12 @@
 {
 	"name": "sly-scrolling",
 	"version": "1.6.1",
+	"description": "JavaScript library for advanced one-directional scrolling with item based navigation support.",
+	"keywords": ["jquery", "scrolling"],
+	"homepage": "http://darsa.in/sly/",
+	"bugs": "https://github.com/darsain/sly/issues",
+	"license": "MIT",
+	"repository": {"type": "git", "url": "https://github.com/darsain/sly"},
 	"peerDependencies": {
 		"jquery": ">=1.7"
 	},


### PR DESCRIPTION
This is a superset of #245, it does:
1. Rename package to `sly-scrolling`;
2. Create another distribution file, `sly.node.js`, which exports `Sly` without bindings to global `jQuery` or `window` objects (#244 requests this);
3. Adds documentation for using the package in a Node environment.

Try it out with `npm install @rq/sly-scrolling` (https://www.npmjs.com/package/@rq/sly-scrolling).
