### PR TITLE
Ceil function is now used when calculating the item size

### DIFF
--- a/src/sly.js
+++ b/src/sly.js
@@ -30,6 +30,7 @@
 	var sqrt = Math.sqrt;
 	var pow = Math.pow;
 	var round = Math.round;
+	var ceil = Math.ceil;
 	var max = Math.max;
 	var min = Math.min;
 
@@ -210,7 +211,7 @@
 					// Item
 					var $item = $(element);
 					var rect = element.getBoundingClientRect();
-					var itemSize = round(o.horizontal ? rect.width || rect.right - rect.left : rect.height || rect.bottom - rect.top);
+					var itemSize = ceil(o.horizontal ? rect.width || rect.right - rect.left : rect.height || rect.bottom - rect.top);
 					var itemMarginStart = getPx($item, o.horizontal ? 'marginLeft' : 'marginTop');
 					var itemMarginEnd = getPx($item, o.horizontal ? 'marginRight' : 'marginBottom');
 					var itemSizeFull = itemSize + itemMarginStart + itemMarginEnd;


### PR DESCRIPTION
This pull request is related to this issue: https://github.com/darsain/sly/issues/200

The problem occurs because the round function is used to calculate the item width. Hence, if the width of an item is 10.3px it will be rounded to 10 and therefore, the calculated width of the frame won't be enough to contain the items.

This is shown here: https://jsfiddle.net/0cvejr3o/

In my pull request, I simply used the ceil function to calculate the width of each item.