### PR TITLE
docs: Fix simple typo, signle -> single

### DIFF
--- a/dist/sly.js
+++ b/dist/sly.js
@@ -1065,7 +1065,7 @@
 		};
 
 		/**
-		 * Updates a signle or multiple option values.
+		 * Updates a single or multiple option values.
 		 *
 		 * @param {Mixed} name  Name of the option that should be updated, or object that will extend the options.
 		 * @param {Mixed} value New option value.

--- a/src/sly.js
+++ b/src/sly.js
@@ -1058,7 +1058,7 @@
 		};
 
 		/**
-		 * Updates a signle or multiple option values.
+		 * Updates a single or multiple option values.
 		 *
 		 * @param {Mixed} name  Name of the option that should be updated, or object that will extend the options.
 		 * @param {Mixed} value New option value.


### PR DESCRIPTION
There is a small typo in dist/sly.js, src/sly.js.

Should read `single` rather than `signle`.

